### PR TITLE
ci: Add codecov in unittests

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,6 +1,6 @@
 name: "Unit Test"
 
-on: [push,pull_request]
+on: [ push,pull_request ]
 
 jobs:
   unit_test:
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         go: [ "1.15", "1.16" ]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
 
     steps:
       - name: Set up Go 1.x
@@ -21,13 +21,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - uses: codecov/codecov-action@v1
-        with:
-          flags: unittests
-          name: codecov
-
       - name: Build
         run: make build
 
       - name: Test
         run: make test
+
+      - uses: codecov/codecov-action@v1
+        with:
+          flags: unittests,${{ matrix.go }},${{ matrix.os }}
+          name: unittests-${{ matrix.go }}-${{ matrix.os }}
+          files: ./coverage.txt

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -21,6 +21,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      - uses: codecov/codecov-action@v1
+        with:
+          flags: unittests
+          name: codecov
+
       - name: Build
         run: make build
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -29,6 +29,6 @@ jobs:
 
       - uses: codecov/codecov-action@v1
         with:
-          flags: unittests,${{ matrix.go }},${{ matrix.os }}
-          name: unittests-${{ matrix.go }}-${{ matrix.os }}
+          flags: unittests
+          name: ${{ matrix.go }}-${{ matrix.os }}
           files: ./coverage.txt

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,10 @@
 coverage:
   range: "0...100" # For now, we will allow any coverage
   status:
+    project:
+      default:
+        target: auto
+        threshold: 0%
     patch:
       default:
         target: auto

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,7 +4,7 @@ coverage:
     project:
       default:
         target: auto
-        threshold: 0%
+        threshold: 100% # For now, we will allow any rate of test dropdown.
     patch:
       default:
         target: auto

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,7 @@
-ignore:
-  - "services/**/generated.go"
-  - "**/error.go"
+coverage:
+  range: "0...100" # For now, we will allow any coverage
+  status:
+    patch:
+      default:
+        target: auto
+        threshold: 100% # For now, we will allow any rate of test dropdown.


### PR DESCRIPTION
We plan to increase the test coverage as tracked in https://github.com/beyondstorage/go-storage/issues/620.

In this PR, I enabled codecov, and allow any rate to be passed (so that we will not block current PRs.)

After https://github.com/beyondstorage/go-storage/issues/620 got closed, we will set the standards for our code test coverage, and any PR that not meet this standard will be refused.

---

Signed-off-by: Xuanwo <github@xuanwo.io>