### PR TITLE
fix: Not enough arguments in call to Service.formatError

### DIFF
--- a/cmd/definitions/gen_service.go
+++ b/cmd/definitions/gen_service.go
@@ -486,12 +486,12 @@ If user enable this feature, service should ignore not support pair error.`),
 				gg.Defer(gg.Embed(func() gg.Node {
 					caller := gg.Call("formatError").WithOwner("s")
 					caller.AddParameter(gg.Lit(fn.Name)).AddParameter("err")
-					for _, v := range op.ParsedParams() {
-						// formatError only accept string as input.
-						if v.Type != "string" {
-							continue
-						}
-						caller.AddParameter(v.Name)
+					paths := op.PathCaller()
+					if len(paths) == 0 && nsNameP == "Service" {
+						caller.AddParameter("\"\"")
+					}
+					for _, v := range paths {
+						caller.AddParameter(v)
 					}
 
 					fn := gg.Function("").

--- a/cmd/definitions/gen_service.go
+++ b/cmd/definitions/gen_service.go
@@ -486,12 +486,18 @@ If user enable this feature, service should ignore not support pair error.`),
 				gg.Defer(gg.Embed(func() gg.Node {
 					caller := gg.Call("formatError").WithOwner("s")
 					caller.AddParameter(gg.Lit(fn.Name)).AddParameter("err")
-					paths := op.PathCaller()
-					if len(paths) == 0 && nsNameP == "Service" {
-						caller.AddParameter("\"\"")
+					paramsNum := 2
+					for _, v := range op.ParsedParams() {
+						// formatError only accept string as input.
+						if v.Type != "string" {
+							continue
+						}
+						caller.AddParameter(v.Name)
+						paramsNum += 1
 					}
-					for _, v := range paths {
-						caller.AddParameter(v)
+					if paramsNum == 2 && nsNameP == "Service" {
+						caller.AddParameter("\"\"")
+						paramsNum += 1
 					}
 
 					fn := gg.Function("").

--- a/cmd/definitions/gen_service.go
+++ b/cmd/definitions/gen_service.go
@@ -486,18 +486,17 @@ If user enable this feature, service should ignore not support pair error.`),
 				gg.Defer(gg.Embed(func() gg.Node {
 					caller := gg.Call("formatError").WithOwner("s")
 					caller.AddParameter(gg.Lit(fn.Name)).AddParameter("err")
-					paramsNum := 2
+					isEmpty := true
 					for _, v := range op.ParsedParams() {
 						// formatError only accept string as input.
 						if v.Type != "string" {
 							continue
 						}
 						caller.AddParameter(v.Name)
-						paramsNum += 1
+						isEmpty = false
 					}
-					if paramsNum == 2 && nsNameP == "Service" {
+					if isEmpty && nsNameP == "Service" {
 						caller.AddParameter("\"\"")
-						paramsNum += 1
 					}
 
 					fn := gg.Function("").

--- a/cmd/definitions/type.go
+++ b/cmd/definitions/type.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"sort"
-	"strings"
 
 	"github.com/Xuanwo/templateutils"
 	"github.com/pelletier/go-toml"
@@ -654,19 +653,6 @@ func (op *Operation) ParsedResults() []*Field {
 	return fs
 }
 
-func (op *Operation) PathCaller() []string {
-	x := make([]string, 0)
-	for _, v := range op.ParsedParams() {
-		if v.Type != "string" {
-			break
-		}
-
-		x = append(x, v.Caller())
-	}
-
-	return x
-}
-
 // Function represents a function.
 type Function struct {
 	Required []string `toml:"required"`
@@ -717,14 +703,6 @@ type Field struct {
 
 	// Runtime generated.
 	Name string
-}
-
-// Caller will print the caller formatGlobal of field.
-func (f *Field) Caller() string {
-	if strings.HasPrefix(f.Type, "...") {
-		return f.Name + "..."
-	}
-	return f.Name
 }
 
 func parseTOML(src []byte, in interface{}) (err error) {

--- a/cmd/definitions/type.go
+++ b/cmd/definitions/type.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"sort"
+	"strings"
 
 	"github.com/Xuanwo/templateutils"
 	"github.com/pelletier/go-toml"
@@ -653,6 +654,19 @@ func (op *Operation) ParsedResults() []*Field {
 	return fs
 }
 
+func (op *Operation) PathCaller() []string {
+	x := make([]string, 0)
+	for _, v := range op.ParsedParams() {
+		if v.Type != "string" {
+			break
+		}
+
+		x = append(x, v.Caller())
+	}
+
+	return x
+}
+
 // Function represents a function.
 type Function struct {
 	Required []string `toml:"required"`
@@ -703,6 +717,14 @@ type Field struct {
 
 	// Runtime generated.
 	Name string
+}
+
+// Caller will print the caller formatGlobal of field.
+func (f *Field) Caller() string {
+	if strings.HasPrefix(f.Type, "...") {
+		return f.Name + "..."
+	}
+	return f.Name
 }
 
 func parseTOML(src []byte, in interface{}) (err error) {

--- a/tests/generated.go
+++ b/tests/generated.go
@@ -408,7 +408,7 @@ func (s *Service) List(pairs ...Pair) (sti *StoragerIterator, err error) {
 func (s *Service) ListWithContext(ctx context.Context, pairs ...Pair) (sti *StoragerIterator, err error) {
 	defer func() {
 		err =
-			s.formatError("list", err)
+			s.formatError("list", err, "")
 	}()
 
 	pairs = append(pairs, s.defaultPairs.List...)


### PR DESCRIPTION
## Issue
Compilation error occured when bump go-storage in go-service-*:
```shell
# github.com/beyondstorage/go-service-qingstor/v3
./generated.go:426:17: not enough arguments in call to s.formatError
        have (string, error)
        want (string, error, string)
# github.com/beyondstorage/go-service-qingstor/v3
vet: ./generated.go:426:29: too few arguments in call to s.formatError
```
## cause
Not generate enough parameters in call to `formatError` for `List` in `Service`.
ref: https://github.com/beyondstorage/go-storage/blob/master/tests/generated.go#L409-L412