### PR TITLE
Make failed 

### DIFF
--- a/services/s3/service.toml
+++ b/services/s3/service.toml
@@ -37,7 +37,7 @@ optional = ["list_mode", "excepted_bucket_owner"]
 
 [namespace.storage.op.read]
 optional = ["content_disposition", "offset", "io_callback", "size", "excepted_bucket_owner", "server_side_encryption_customer_algorithm", "server_side_encryption_customer_key"]
-s
+
 [namespace.storage.op.write]
 optional = ["content_md5", "content_type", "io_callback", "storage_class", "excepted_bucket_owner", "server_side_encryption_bucket_key_enabled", "server_side_encryption_customer_algorithm", "server_side_encryption_customer_key", "server_side_encryption_aws_kms_key_id", "server_side_encryption_context", "server_side_encryption"]
 


### PR DESCRIPTION
After I add `content_disposition` to global pairs.
I want to add `content_disposition` to service s3's service.toml too.
But when I make build, an error occurred.
Maybe I lost some steps?

```go
go mod tidy
go mod verify
all modules verified
generate code
go generate ./...
FATA[0000] pair content_disposition is not registered
exit status 1
doc.go:6: running "go": exit status 1
make: *** [Makefile:24: generate] Error 1
```