### PR TITLE
Add field in StorageMeta to hold the service name

### DIFF
--- a/definitions/infos.go
+++ b/definitions/infos.go
@@ -196,7 +196,7 @@ var InfosStorageMetaArray = []Info{
 		Name:        "service",
 		Type:        Type{Name: "string"},
 		export:      true,
-		Description: "Name of Services",
+		Description: "Service name.",
 	},
 }
 

--- a/definitions/infos.go
+++ b/definitions/infos.go
@@ -193,7 +193,7 @@ var InfosStorageMetaArray = []Info{
 		Description: "Maximum size for write operation.",
 	},
 	{
-		Name:        "service_name",
+		Name:        "service",
 		Type:        Type{Name: "string"},
 		export:      true,
 		Description: "Name of Services",

--- a/definitions/infos.go
+++ b/definitions/infos.go
@@ -1,8 +1,9 @@
 package definitions
 
 import (
-	"github.com/Xuanwo/templateutils"
 	"sort"
+
+	"github.com/Xuanwo/templateutils"
 )
 
 type Info struct {
@@ -191,6 +192,12 @@ var InfosStorageMetaArray = []Info{
 		Type:        Type{Name: "int64"},
 		Description: "Maximum size for write operation.",
 	},
+	{
+		Name:        "service_name",
+		Type:        Type{Name: "string"},
+		export:      true,
+		Description: "Name of Services",
+	},
 }
 
 func init() {
@@ -200,8 +207,8 @@ func init() {
 		InfosObjectMetaArray[k].global = true
 	}
 	for k := range InfosStorageMetaArray {
-		InfosObjectMetaArray[k].Namespace = NamespaceStorage
-		InfosObjectMetaArray[k].Category = CategoryMeta
-		InfosObjectMetaArray[k].global = true
+		InfosStorageMetaArray[k].Namespace = NamespaceStorage
+		InfosStorageMetaArray[k].Category = CategoryMeta
+		InfosStorageMetaArray[k].global = true
 	}
 }

--- a/types/info.generated.go
+++ b/types/info.generated.go
@@ -16,9 +16,10 @@ const (
 	storageMetaIndexMultipartSizeMaximum   = 1 << 8
 	storageMetaIndexMultipartSizeMinimum   = 1 << 9
 	storageMetaIndexName                   = 1 << 10
-	storageMetaIndexSystemMetadata         = 1 << 11
-	storageMetaIndexWorkDir                = 1 << 12
-	storageMetaIndexWriteSizeMaximum       = 1 << 13
+	storageMetaIndexServiceName            = 1 << 11
+	storageMetaIndexSystemMetadata         = 1 << 12
+	storageMetaIndexWorkDir                = 1 << 13
+	storageMetaIndexWriteSizeMaximum       = 1 << 14
 )
 
 type StorageMeta struct {
@@ -33,6 +34,7 @@ type StorageMeta struct {
 	multipartSizeMaximum   int64
 	multipartSizeMinimum   int64
 	Name                   string
+	ServiceName            string
 	systemMetadata         interface{}
 	WorkDir                string
 	writeSizeMaximum       int64
@@ -217,6 +219,13 @@ func (m *StorageMeta) GetName() string {
 }
 func (m *StorageMeta) SetName(v string) *StorageMeta {
 	m.Name = v
+	return m
+}
+func (m *StorageMeta) GetServiceName() string {
+	return m.ServiceName
+}
+func (m *StorageMeta) SetServiceName(v string) *StorageMeta {
+	m.ServiceName = v
 	return m
 }
 func (m *StorageMeta) GetSystemMetadata() (interface{}, bool) {

--- a/types/info.generated.go
+++ b/types/info.generated.go
@@ -16,7 +16,7 @@ const (
 	storageMetaIndexMultipartSizeMaximum   = 1 << 8
 	storageMetaIndexMultipartSizeMinimum   = 1 << 9
 	storageMetaIndexName                   = 1 << 10
-	storageMetaIndexServiceName            = 1 << 11
+	storageMetaIndexService                = 1 << 11
 	storageMetaIndexSystemMetadata         = 1 << 12
 	storageMetaIndexWorkDir                = 1 << 13
 	storageMetaIndexWriteSizeMaximum       = 1 << 14
@@ -34,7 +34,7 @@ type StorageMeta struct {
 	multipartSizeMaximum   int64
 	multipartSizeMinimum   int64
 	Name                   string
-	ServiceName            string
+	Service                string
 	systemMetadata         interface{}
 	WorkDir                string
 	writeSizeMaximum       int64
@@ -221,11 +221,11 @@ func (m *StorageMeta) SetName(v string) *StorageMeta {
 	m.Name = v
 	return m
 }
-func (m *StorageMeta) GetServiceName() string {
-	return m.ServiceName
+func (m *StorageMeta) GetService() string {
+	return m.Service
 }
-func (m *StorageMeta) SetServiceName(v string) *StorageMeta {
-	m.ServiceName = v
+func (m *StorageMeta) SetService(v string) *StorageMeta {
+	m.Service = v
 	return m
 }
 func (m *StorageMeta) GetSystemMetadata() (interface{}, bool) {


### PR DESCRIPTION
Add field in StorageMeta to hold the service name

Fix wrong function usage in init function.

[original issue](https://github.com/beyondstorage/go-storage/issues/977)