### PR TITLE
feat(services/s3): Remove service test on minio for s3

### DIFF
--- a/.github/workflows/services-test-s3.yml
+++ b/.github/workflows/services-test-s3.yml
@@ -44,38 +44,3 @@ jobs:
           STORAGE_S3_INTEGRATION_TEST: on
         working-directory: services/s3
         run: make integration_test
-  
-  service_test_minio:
-    name: "Service Test Minio"
-    runs-on: ubuntu-latest
-
-    services:
-      minio:
-        image: wktk/minio-server
-        ports:
-          - 9000:9000
-        env:
-          MINIO_ACCESS_KEY: "minioadmin"
-          MINIO_SECRET_KEY: "minioadmin"
-
-    strategy:
-      matrix:
-        go: [ "1.16", "1.17" ]
-
-    steps:
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v2
-        with:
-          go-version: ${{ matrix.go }}
-
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Test
-        env:
-          STORAGE_MINIO_INTEGRATION_TEST: "on"
-          STORAGE_MINIO_CREDENTIAL: "hmac:minioadmin:minioadmin"
-          STORAGE_MINIO_NAME: "test-bucket"
-          STORAGE_MINIO_ENDPOINT: "http:127.0.0.1:9000"
-        working-directory: services/minio
-        run: make integration_test


### PR DESCRIPTION
Currently service test on minio for s3 can't pass because of [issue 924](https://github.com/beyondstorage/go-storage/issues/924). We have to revoke it.
We will solve this problem in [issue 1000](tests: List with ListModePart should be on specific path #1000).