### PR TITLE
services/s3: Fix issue 924

### DIFF
--- a/tests/multiparter.go
+++ b/tests/multiparter.go
@@ -243,7 +243,7 @@ func TestMultiparter(t *testing.T, store types.Storager) {
 				t.Error(err)
 			}
 
-			it, err := store.List("", pairs.WithListMode(types.ListModePart))
+			it, err := store.List(path, pairs.WithListMode(types.ListModePart))
 			Convey("The error should be nil", func() {
 				So(err, ShouldBeNil)
 			})


### PR DESCRIPTION
Give store.List a specific path.
According to [minio/minio#11686](https://github.com/minio/minio/issues/11686), List multipart uploads only return values for exact object name. 

